### PR TITLE
Add DR Genie cross-reference fields and MapBase specs

### DIFF
--- a/lib/common/map/map_base.rb
+++ b/lib/common/map/map_base.rb
@@ -250,6 +250,12 @@ module Lich
           end.join("\n")
         end
 
+        # Override in subclasses to add game-specific fields to JSON output.
+        # Must return a Hash. Nil/empty values are filtered automatically.
+        def json_extra_fields
+          {}
+        end
+
         # Convert room to JSON
         def to_json(*_args)
           mapjson = {
@@ -268,7 +274,9 @@ module Lich
             check_location: @check_location,
             unique_loot: @unique_loot,
             uid: @uid
-          }.delete_if { |_a, b| b.nil? || (b.is_a?(Array) && b.empty?) }
+          }
+          mapjson.merge!(json_extra_fields)
+          mapjson.delete_if { |_a, b| b.nil? || (b.is_a?(Array) && b.empty?) }
           JSON.pretty_generate(mapjson)
         end
 

--- a/lib/common/map/map_dr.rb
+++ b/lib/common/map/map_dr.rb
@@ -28,12 +28,14 @@ module Lich
       attr_reader :id
       attr_accessor :title, :description, :paths, :location, :climate, :terrain,
                     :wayto, :timeto, :image, :image_coords, :tags, :check_location,
-                    :unique_loot, :uid, :room_objects
+                    :unique_loot, :uid, :room_objects,
+                    :genie_id, :genie_zone, :genie_pos
 
       def initialize(id, title, description, paths, uid = [], location = nil,
                      climate = nil, terrain = nil, wayto = {}, timeto = {},
                      image = nil, image_coords = nil, tags = [], check_location = nil,
-                     unique_loot = nil, _room_objects = nil)
+                     unique_loot = nil, _room_objects = nil,
+                     genie_id = nil, genie_zone = nil, genie_pos = nil)
         @id = id
         @title = title
         @description = description
@@ -49,11 +51,18 @@ module Lich
         @tags = tags
         @check_location = check_location
         @unique_loot = unique_loot
+        @genie_id = genie_id
+        @genie_zone = genie_zone
+        @genie_pos = genie_pos
         @@list[@id] = self
       end
 
       def to_s
         "##{@id} (#{@uid[-1]}):\n#{@title[-1]}\n#{@description[-1]}\n#{@paths[-1]}"
+      end
+
+      def json_extra_fields
+        { genie_id: @genie_id, genie_zone: @genie_zone, genie_pos: @genie_pos }
       end
 
       # Class method accessors
@@ -86,6 +95,11 @@ module Lich
         def synchronize_load(&block)
           @@load_mutex.synchronize(&block)
         end
+      end
+
+      def self.by_genie_ref(zone_id, node_id)
+        self.load unless @@loaded
+        @@list.find { |r| r&.genie_zone == zone_id.to_s && r&.genie_id == node_id.to_s }
       end
 
       def self.get_free_id
@@ -395,7 +409,9 @@ module Lich
                   room['id'], room['title'], room['description'], room['paths'],
                   room['uid'], room['location'], room['climate'], room['terrain'],
                   room['wayto'], room['timeto'], room['image'], room['image_coords'],
-                  room['tags'], room['check_location'], room['unique_loot']
+                  room['tags'], room['check_location'], room['unique_loot'],
+                  nil, # _room_objects
+                  room['genie_id'], room['genie_zone'], room['genie_pos']
                 )
               end
             end

--- a/spec/map_base_spec.rb
+++ b/spec/map_base_spec.rb
@@ -1,0 +1,560 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'json'
+
+LIB_DIR = File.join(File.expand_path('..', File.dirname(__FILE__)), 'lib') unless defined?(LIB_DIR)
+
+# Minimal mocks for map_base.rb dependencies
+class StringProc
+  attr_reader :_dump
+
+  def initialize(str)
+    @_dump = str
+  end
+
+  def call
+    0.2
+  end
+
+  def to_json(*_args)
+    ";e #{@_dump}".to_json
+  end
+end
+
+module XMLData
+  class << self
+    attr_accessor :game
+  end
+end
+
+DATA_DIR = '/tmp/lich_test_data'
+
+def respond(msg = '')
+  # mock
+end
+
+def echo(msg = '')
+  # mock
+end
+
+require File.join(LIB_DIR, 'common', 'map', 'map_base.rb')
+
+RSpec.describe Lich::Common::MinHeap do
+  subject(:heap) { described_class.new }
+
+  describe '#push and #pop' do
+    it 'returns nil when empty' do
+      expect(heap.pop).to be_nil
+    end
+
+    it 'returns the single pushed element' do
+      heap.push(5, :a)
+      expect(heap.pop).to eq([5, :a])
+    end
+
+    it 'pops elements in priority order' do
+      heap.push(3, :c)
+      heap.push(1, :a)
+      heap.push(2, :b)
+
+      expect(heap.pop).to eq([1, :a])
+      expect(heap.pop).to eq([2, :b])
+      expect(heap.pop).to eq([3, :c])
+    end
+
+    it 'handles duplicate priorities' do
+      heap.push(1, :a)
+      heap.push(1, :b)
+
+      result = [heap.pop, heap.pop].map(&:last)
+      expect(result).to contain_exactly(:a, :b)
+    end
+
+    it 'handles many elements correctly' do
+      values = (1..100).to_a.shuffle
+      values.each { |v| heap.push(v, v) }
+
+      sorted = []
+      sorted << heap.pop[0] until heap.empty?
+      expect(sorted).to eq((1..100).to_a)
+    end
+  end
+
+  describe '#empty?' do
+    it 'is true when newly created' do
+      expect(heap).to be_empty
+    end
+
+    it 'is false after push' do
+      heap.push(1, :a)
+      expect(heap).not_to be_empty
+    end
+
+    it 'is true after popping all elements' do
+      heap.push(1, :a)
+      heap.pop
+      expect(heap).to be_empty
+    end
+  end
+end
+
+# Create a concrete test class that includes MapBase
+# This mimics how map_dr.rb and map_gs.rb use it
+module TestMap
+  class Map
+    include Lich::Common::MapBase
+
+    @@loaded = false
+    @@load_mutex = Mutex.new
+    @@list = []
+    @@tags = []
+    @@uids = {}
+
+    attr_reader :id
+    attr_accessor :title, :description, :paths, :location, :climate, :terrain,
+                  :wayto, :timeto, :image, :image_coords, :tags, :check_location,
+                  :unique_loot, :uid
+
+    def initialize(id, title = [], description = [], paths = [], uid = [],
+                   location = nil, climate = nil, terrain = nil,
+                   wayto = {}, timeto = {}, image = nil, image_coords = nil,
+                   tags = [], check_location = nil, unique_loot = nil)
+      @id = id
+      @title = title
+      @description = description
+      @paths = paths
+      @uid = uid
+      @location = location
+      @climate = climate
+      @terrain = terrain
+      @wayto = wayto
+      @timeto = timeto
+      @image = image
+      @image_coords = image_coords
+      @tags = tags
+      @check_location = check_location
+      @unique_loot = unique_loot
+      @@list[@id] = self
+    end
+
+    class << self
+      def loaded?
+        @@loaded
+      end
+
+      def list
+        @@list
+      end
+
+      def list=(value)
+        @@list = value
+      end
+
+      def uids
+        @@uids
+      end
+
+      def clear_tags_cache
+        @@tags.clear
+      end
+
+      def mark_loaded
+        @@loaded = true
+      end
+
+      def synchronize_load(&block)
+        @@load_mutex.synchronize(&block)
+      end
+
+      def load
+        @@loaded = true
+      end
+
+      def [](val)
+        self.load unless @@loaded
+        if val.is_a?(Integer) || val =~ /^[0-9]+$/
+          @@list[val.to_i]
+        else
+          @@list.find { |room| room&.title&.include?(val) }
+        end
+      end
+
+      def clear_test_data
+        @@list = []
+        @@tags = []
+        @@uids = {}
+        @@loaded = false
+      end
+    end
+  end
+end
+
+RSpec.describe Lich::Common::MapBase do
+  before(:each) do
+    TestMap::Map.clear_test_data
+    TestMap::Map.mark_loaded
+  end
+
+  describe 'InstanceMethods' do
+    let(:room) do
+      TestMap::Map.new(
+        42,
+        ['[Town Square]'],
+        ['A busy town square.'],
+        ['Obvious paths: north, south, east'],
+        [12_345],
+        'Wehnimers Landing',
+        nil, nil,
+        { '43' => 'north', '44' => 'south' },
+        { '43' => 0.2, '44' => 0.3 },
+        'wl-square',
+        [100, 200, 108, 208],
+        %w[town bank],
+        nil, nil
+      )
+    end
+
+    describe '#to_i' do
+      it 'returns the room id' do
+        expect(room.to_i).to eq(42)
+      end
+    end
+
+    describe '#outside?' do
+      it 'returns true when paths say "Obvious paths:"' do
+        expect(room.outside?).to be true
+      end
+
+      it 'returns false when paths say "Obvious exits:"' do
+        room.paths = ['Obvious exits: north, south']
+        expect(room.outside?).to be false
+      end
+
+      it 'returns false when paths is empty' do
+        room.paths = []
+        expect(room.outside?).to be false
+      end
+
+      it 'returns false when paths is nil' do
+        room.paths = nil
+        expect(room.outside?).to be false
+      end
+    end
+
+    describe '#inside?' do
+      it 'returns false when outside' do
+        expect(room.inside?).to be false
+      end
+
+      it 'returns true when paths say "Obvious exits:"' do
+        room.paths = ['Obvious exits: north']
+        expect(room.inside?).to be true
+      end
+    end
+
+    describe '#desc' do
+      it 'returns the description' do
+        expect(room.desc).to eq(['A busy town square.'])
+      end
+    end
+
+    describe '#map_name' do
+      it 'returns the image name' do
+        expect(room.map_name).to eq('wl-square')
+      end
+    end
+
+    describe '#map_x' do
+      it 'returns the center x coordinate' do
+        expect(room.map_x).to eq(104)
+      end
+
+      it 'returns nil when image_coords is nil' do
+        room.image_coords = nil
+        expect(room.map_x).to be_nil
+      end
+    end
+
+    describe '#map_y' do
+      it 'returns the center y coordinate' do
+        expect(room.map_y).to eq(204)
+      end
+
+      it 'returns nil when image_coords is nil' do
+        room.image_coords = nil
+        expect(room.map_y).to be_nil
+      end
+    end
+
+    describe '#map_roomsize' do
+      it 'returns the room size' do
+        expect(room.map_roomsize).to eq(8)
+      end
+
+      it 'returns nil when image_coords is nil' do
+        room.image_coords = nil
+        expect(room.map_roomsize).to be_nil
+      end
+    end
+
+    describe '#geo' do
+      it 'returns nil' do
+        expect(room.geo).to be_nil
+      end
+    end
+
+    describe '#inspect' do
+      it 'includes instance variable details' do
+        result = room.inspect
+        expect(result).to include('@id=42')
+        expect(result).to include('@title=')
+      end
+    end
+
+    describe '#to_json' do
+      it 'produces valid JSON' do
+        json_string = room.to_json
+        parsed = JSON.parse(json_string)
+        expect(parsed['id']).to eq(42)
+        expect(parsed['title']).to eq(['[Town Square]'])
+        expect(parsed['wayto']).to eq({ '43' => 'north', '44' => 'south' })
+      end
+
+      it 'excludes nil fields' do
+        json_string = room.to_json
+        parsed = JSON.parse(json_string)
+        expect(parsed).not_to have_key('climate')
+        expect(parsed).not_to have_key('terrain')
+      end
+
+      it 'excludes empty array fields' do
+        room.tags = []
+        json_string = room.to_json
+        parsed = JSON.parse(json_string)
+        expect(parsed).not_to have_key('tags')
+      end
+
+      it 'returns empty hash from json_extra_fields by default' do
+        expect(room.json_extra_fields).to eq({})
+      end
+
+      it 'merges json_extra_fields into output' do
+        allow(room).to receive(:json_extra_fields).and_return({ custom_field: 'test_value' })
+        json_string = room.to_json
+        parsed = JSON.parse(json_string)
+        expect(parsed['custom_field']).to eq('test_value')
+      end
+
+      it 'filters nil values from json_extra_fields' do
+        allow(room).to receive(:json_extra_fields).and_return({ custom_field: nil })
+        json_string = room.to_json
+        parsed = JSON.parse(json_string)
+        expect(parsed).not_to have_key('custom_field')
+      end
+    end
+  end
+
+  describe 'ClassMethods' do
+    describe '.get_free_id' do
+      it 'returns one more than the max existing id' do
+        TestMap::Map.new(0, ['Room 0'])
+        TestMap::Map.new(5, ['Room 5'])
+        TestMap::Map.new(3, ['Room 3'])
+
+        expect(TestMap::Map.get_free_id).to eq(6)
+      end
+    end
+
+    describe '.estimate_time' do
+      it 'sums timeto values along a path' do
+        TestMap::Map.new(0, [], [], [], [], nil, nil, nil,
+                         { '1' => 'north' }, { '1' => 0.5 })
+        TestMap::Map.new(1, [], [], [], [], nil, nil, nil,
+                         { '2' => 'east' }, { '2' => 0.3 })
+        TestMap::Map.new(2)
+
+        expect(TestMap::Map.estimate_time([0, 1, 2])).to be_within(0.001).of(0.8)
+      end
+
+      it 'uses 0.2 as default when timeto is nil' do
+        TestMap::Map.new(0, [], [], [], [], nil, nil, nil,
+                         { '1' => 'north' }, {})
+        TestMap::Map.new(1)
+
+        expect(TestMap::Map.estimate_time([0, 1])).to be_within(0.001).of(0.2)
+      end
+
+      it 'raises on non-array input' do
+        expect { TestMap::Map.estimate_time('not an array') }.to raise_error(Exception)
+      end
+    end
+
+    describe '.uids_add and .ids_from_uid' do
+      it 'adds and retrieves uid mappings' do
+        TestMap::Map.uids_add(100, 5)
+        TestMap::Map.uids_add(100, 6)
+        expect(TestMap::Map.ids_from_uid(100)).to eq([5, 6])
+      end
+
+      it 'returns empty array for unknown uid' do
+        expect(TestMap::Map.ids_from_uid(999)).to eq([])
+      end
+
+      it 'does not add duplicate ids' do
+        TestMap::Map.uids_add(100, 5)
+        TestMap::Map.uids_add(100, 5)
+        expect(TestMap::Map.ids_from_uid(100)).to eq([5])
+      end
+    end
+
+    describe '.to_json' do
+      it 'produces valid JSON array' do
+        TestMap::Map.new(0, ['Room A'], ['Desc A'], ['Paths A'])
+        TestMap::Map.new(1, ['Room B'], ['Desc B'], ['Paths B'])
+
+        json_string = TestMap::Map.to_json
+        parsed = JSON.parse(json_string)
+        expect(parsed).to be_an(Array)
+        expect(parsed.size).to eq(2)
+        expect(parsed[0]['id']).to eq(0)
+        expect(parsed[1]['id']).to eq(1)
+      end
+    end
+  end
+
+  describe 'pathfinding' do
+    # Build a small graph:
+    #   0 --0.2--> 1 --0.3--> 2
+    #   |                      ^
+    #   +--------1.0-----------+
+    before(:each) do
+      TestMap::Map.new(0, [], [], [], [], nil, nil, nil,
+                       { '1' => 'north', '2' => 'east' },
+                       { '1' => 0.2, '2' => 1.0 })
+      TestMap::Map.new(1, [], [], [], [], nil, nil, nil,
+                       { '2' => 'east' },
+                       { '2' => 0.3 })
+      TestMap::Map.new(2, [], [], [], [], nil, nil, nil,
+                       {}, {})
+    end
+
+    describe '#dijkstra' do
+      it 'finds shortest distances' do
+        room0 = TestMap::Map.list[0]
+        _, distances = room0.dijkstra
+
+        expect(distances[0]).to eq(0)
+        expect(distances[1]).to eq(0.2)
+        expect(distances[2]).to eq(0.5) # 0.2 + 0.3 < 1.0
+      end
+
+      it 'returns previous pointers for path reconstruction' do
+        room0 = TestMap::Map.list[0]
+        previous, = room0.dijkstra
+
+        expect(previous[1]).to eq(0)
+        expect(previous[2]).to eq(1) # via room 1, not direct
+      end
+
+      it 'terminates early when destination reached' do
+        room0 = TestMap::Map.list[0]
+        previous, _ = room0.dijkstra(1)
+
+        expect(previous[1]).to eq(0)
+      end
+    end
+
+    describe '#path_to' do
+      it 'returns the shortest path excluding source' do
+        room0 = TestMap::Map.list[0]
+        path = room0.path_to(2)
+
+        expect(path).to eq([1, 2])
+      end
+
+      it 'returns nil when no path exists' do
+        TestMap::Map.new(99, [], [], [], [], nil, nil, nil, {}, {})
+        room0 = TestMap::Map.list[0]
+        path = room0.path_to(99)
+
+        expect(path).to be_nil
+      end
+
+      it 'returns single-element path for adjacent rooms' do
+        room0 = TestMap::Map.list[0]
+        path = room0.path_to(1)
+
+        expect(path).to eq([1])
+      end
+    end
+
+    describe '#find_nearest' do
+      it 'finds the nearest room from a list' do
+        room0 = TestMap::Map.list[0]
+        nearest = room0.find_nearest([1, 2])
+
+        expect(nearest).to eq(1)
+      end
+
+      it 'returns self id when included in target list' do
+        room0 = TestMap::Map.list[0]
+        nearest = room0.find_nearest([0, 1, 2])
+
+        expect(nearest).to eq(0)
+      end
+    end
+
+    describe '#find_nearest_by_tag' do
+      it 'finds the nearest room with a matching tag' do
+        TestMap::Map.list[2].tags = ['bank']
+
+        room0 = TestMap::Map.list[0]
+        nearest = room0.find_nearest_by_tag('bank')
+
+        expect(nearest).to eq(2)
+      end
+
+      it 'returns self id when current room has the tag' do
+        TestMap::Map.list[0].tags = ['bank']
+
+        room0 = TestMap::Map.list[0]
+        nearest = room0.find_nearest_by_tag('bank')
+
+        expect(nearest).to eq(0)
+      end
+    end
+
+    describe '#find_all_nearest_by_tag' do
+      it 'returns all tagged rooms sorted by distance' do
+        TestMap::Map.list[1].tags = ['shop']
+        TestMap::Map.list[2].tags = ['shop']
+
+        room0 = TestMap::Map.list[0]
+        result = room0.find_all_nearest_by_tag('shop')
+
+        expect(result).to eq([1, 2])
+      end
+    end
+
+    describe '.findpath' do
+      it 'finds path between two room ids' do
+        path = TestMap::Map.findpath(0, 2)
+        expect(path).to eq([1, 2])
+      end
+
+      it 'accepts a Room object as source' do
+        room0 = TestMap::Map.list[0]
+        path = TestMap::Map.findpath(room0, 2)
+        expect(path).to eq([1, 2])
+      end
+    end
+
+    describe '.dijkstra class method' do
+      it 'dispatches to instance dijkstra' do
+        previous, _ = TestMap::Map.dijkstra(0, 2)
+        expect(previous[2]).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/map_dr_spec.rb
+++ b/spec/map_dr_spec.rb
@@ -1,0 +1,251 @@
+# frozen_string_literal: true
+
+# NOTE: This spec must be run individually, not combined with map_gs_spec.rb.
+# Both map_dr.rb and map_gs.rb define Lich::Common::Map (one per game).
+# Run: rspec spec/map_dr_spec.rb
+
+require 'rspec'
+require 'json'
+
+LIB_DIR = File.join(File.expand_path('..', File.dirname(__FILE__)), 'lib') unless defined?(LIB_DIR)
+
+# Minimal mocks for map_dr.rb dependencies
+class StringProc
+  attr_reader :_dump
+
+  def initialize(str)
+    @_dump = str
+  end
+
+  def call
+    0.2
+  end
+
+  def to_json(*_args)
+    ";e #{@_dump}".to_json
+  end
+end unless defined?(StringProc)
+
+module XMLData
+  class << self
+    attr_accessor :game, :room_count, :room_id, :room_title, :room_description,
+                  :room_exits_string, :room_window_disabled, :previous_nav_rm
+  end
+end unless defined?(XMLData)
+
+DATA_DIR = '/tmp/lich_test_data' unless defined?(DATA_DIR)
+
+module Script
+  class << self
+    def current
+      nil
+    end
+  end
+end unless defined?(Script)
+
+def respond(msg = '')
+  # mock
+end
+
+def echo(msg = '')
+  # mock
+end
+
+require File.join(LIB_DIR, 'common', 'map', 'map_dr.rb')
+
+RSpec.describe Lich::Common::Map do
+  # Reset class state between tests
+  before(:each) do
+    # Clear the list and reset loaded state
+    Lich::Common::Map.send(:class_variable_set, :@@list, [])
+    Lich::Common::Map.send(:class_variable_set, :@@tags, [])
+    Lich::Common::Map.send(:class_variable_set, :@@uids, {})
+    Lich::Common::Map.send(:class_variable_set, :@@loaded, true)
+  end
+
+  describe 'Genie field support' do
+    describe '#initialize' do
+      it 'accepts genie fields as parameters' do
+        room = Lich::Common::Map.new(
+          1, ['[Crossing]'], ['The main square.'], ['Obvious paths: north'],
+          [100], nil, nil, nil, {}, {}, nil, nil, [], nil, nil, nil,
+          'node42', 'zone1', [520, 120, 0]
+        )
+
+        expect(room.genie_id).to eq('node42')
+        expect(room.genie_zone).to eq('zone1')
+        expect(room.genie_pos).to eq([520, 120, 0])
+      end
+
+      it 'defaults genie fields to nil' do
+        room = Lich::Common::Map.new(
+          2, ['[Town]'], ['A town.'], ['Obvious paths: east'],
+          [200]
+        )
+
+        expect(room.genie_id).to be_nil
+        expect(room.genie_zone).to be_nil
+        expect(room.genie_pos).to be_nil
+      end
+    end
+
+    describe 'attr_accessor' do
+      let(:room) do
+        Lich::Common::Map.new(3, ['[Room]'], ['Desc.'], ['Paths'])
+      end
+
+      it 'allows reading and writing genie_id' do
+        room.genie_id = 'node99'
+        expect(room.genie_id).to eq('node99')
+      end
+
+      it 'allows reading and writing genie_zone' do
+        room.genie_zone = 'zone55'
+        expect(room.genie_zone).to eq('zone55')
+      end
+
+      it 'allows reading and writing genie_pos' do
+        room.genie_pos = [100, 200, 0]
+        expect(room.genie_pos).to eq([100, 200, 0])
+      end
+    end
+
+    describe '#json_extra_fields' do
+      it 'returns genie fields hash' do
+        room = Lich::Common::Map.new(
+          10, ['[Room]'], ['Desc'], ['Paths'],
+          [], nil, nil, nil, {}, {}, nil, nil, [], nil, nil, nil,
+          'node5', 'zone3', [100, 200, 0]
+        )
+
+        extra = room.json_extra_fields
+        expect(extra[:genie_id]).to eq('node5')
+        expect(extra[:genie_zone]).to eq('zone3')
+        expect(extra[:genie_pos]).to eq([100, 200, 0])
+      end
+    end
+
+    describe '#to_json' do
+      it 'includes genie fields when present' do
+        room = Lich::Common::Map.new(
+          10, ['[Room]'], ['Desc'], ['Paths'],
+          [], nil, nil, nil, {}, {}, nil, nil, [], nil, nil, nil,
+          'node5', 'zone3', [100, 200, 0]
+        )
+
+        json_string = room.to_json
+        parsed = JSON.parse(json_string)
+
+        expect(parsed['genie_id']).to eq('node5')
+        expect(parsed['genie_zone']).to eq('zone3')
+        expect(parsed['genie_pos']).to eq([100, 200, 0])
+      end
+
+      it 'excludes genie fields when nil' do
+        room = Lich::Common::Map.new(
+          11, ['[Room]'], ['Desc'], ['Paths']
+        )
+
+        json_string = room.to_json
+        parsed = JSON.parse(json_string)
+
+        expect(parsed).not_to have_key('genie_id')
+        expect(parsed).not_to have_key('genie_zone')
+        expect(parsed).not_to have_key('genie_pos')
+      end
+    end
+
+    describe '.by_genie_ref' do
+      before(:each) do
+        Lich::Common::Map.new(
+          20, ['[Room A]'], ['Desc A'], ['Paths'],
+          [], nil, nil, nil, {}, {}, nil, nil, [], nil, nil, nil,
+          '42', '1', [520, 120, 0]
+        )
+        Lich::Common::Map.new(
+          21, ['[Room B]'], ['Desc B'], ['Paths'],
+          [], nil, nil, nil, {}, {}, nil, nil, [], nil, nil, nil,
+          '335', '1', [540, 140, 0]
+        )
+        Lich::Common::Map.new(
+          22, ['[Room C]'], ['Desc C'], ['Paths'],
+          [], nil, nil, nil, {}, {}, nil, nil, [], nil, nil, nil,
+          '1', '2', [100, 100, 0]
+        )
+      end
+
+      it 'finds room by zone and node id' do
+        room = Lich::Common::Map.by_genie_ref('1', '42')
+        expect(room).not_to be_nil
+        expect(room.id).to eq(20)
+      end
+
+      it 'finds different node in same zone' do
+        room = Lich::Common::Map.by_genie_ref('1', '335')
+        expect(room).not_to be_nil
+        expect(room.id).to eq(21)
+      end
+
+      it 'finds node in different zone' do
+        room = Lich::Common::Map.by_genie_ref('2', '1')
+        expect(room).not_to be_nil
+        expect(room.id).to eq(22)
+      end
+
+      it 'returns nil for nonexistent reference' do
+        room = Lich::Common::Map.by_genie_ref('999', '999')
+        expect(room).to be_nil
+      end
+
+      it 'converts integer arguments to strings for comparison' do
+        room = Lich::Common::Map.by_genie_ref(1, 42)
+        expect(room).not_to be_nil
+        expect(room.id).to eq(20)
+      end
+    end
+  end
+
+  describe 'standard Map functionality' do
+    describe '#to_s' do
+      it 'formats room as string' do
+        room = Lich::Common::Map.new(
+          50, ['[Town Square]'], ['A busy square.'], ['Obvious paths: north'],
+          [12_345]
+        )
+        result = room.to_s
+        expect(result).to include('#50')
+        expect(result).to include('12345')
+        expect(result).to include('[Town Square]')
+      end
+    end
+
+    describe '.[]' do
+      before(:each) do
+        Lich::Common::Map.new(0, ['[Room Zero]'], ['Zero desc'], ['Paths'])
+        Lich::Common::Map.new(1, ['[Room One]'], ['One desc'], ['Paths'])
+      end
+
+      it 'looks up by integer id' do
+        room = Lich::Common::Map[0]
+        expect(room.title).to eq(['[Room Zero]'])
+      end
+
+      it 'looks up by string id' do
+        room = Lich::Common::Map['1']
+        expect(room.title).to eq(['[Room One]'])
+      end
+
+      it 'looks up by title search' do
+        room = Lich::Common::Map['Room One']
+        expect(room).not_to be_nil
+        expect(room.id).to eq(1)
+      end
+    end
+
+    describe 'Room alias' do
+      it 'exists as subclass of Map' do
+        expect(Lich::Common::Room.superclass).to eq(Lich::Common::Map)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds Genie map cross-reference fields to the DragonRealms map data model, enabling external tooling to link Lich rooms to their corresponding Genie zone/node IDs and positions. Also adds comprehensive RSpec coverage for the shared `MapBase` module and DR-specific map functionality.

- Add `json_extra_fields` hook to `MapBase` for game-specific JSON extensions
- DR overrides `json_extra_fields` to include `genie_id`, `genie_zone`, `genie_pos`
- Add `genie_id`, `genie_zone`, `genie_pos` attributes to DR `Map` class (attr_accessor, initialize, load_json)
- Add `Map.by_genie_ref(zone_id, node_id)` class method for Genie-based room lookup
- Add `spec/map_base_spec.rb` (53 examples) covering MinHeap, pathfinding, instance/class methods
- Add `spec/map_dr_spec.rb` (18 examples) covering genie fields, `by_genie_ref`, and DR-specific behavior

## Motivation

The Genie front-end for DragonRealms maintains its own map database (~18,900 nodes across 92 zone XML files) with hand-tuned room positions. By storing the Genie zone ID, node ID, and position coordinates on each Lich room, we enable:

1. **Cross-reference lookup** — find a Lich room from a Genie zone:node reference (and vice versa)
2. **Position data for rendering** — use Genie's hand-tuned `[x, y, z]` positions for dynamic map rendering without depending on Genie files at runtime
3. **Import tooling** — a separate import script (not in this PR) can match Lich rooms to Genie nodes and write these fields into the map JSON

## Changes

### `lib/common/map/map_base.rb` (+9/-1)

Added a `json_extra_fields` hook method that returns `{}` by default. Subclasses override it to inject game-specific fields into JSON output. `to_json` merges the result and the existing `delete_if nil` filter auto-excludes unset fields. This keeps game-specific knowledge out of the shared module.

```ruby
# map_base.rb — generic hook
def json_extra_fields
  {}
end

def to_json(*)
  mapjson = { id: @id, title: @title, ... }
  mapjson.merge!(json_extra_fields)
  mapjson.delete_if { |_a, b| b.nil? || (b.is_a?(Array) && b.empty?) }
  JSON.pretty_generate(mapjson)
end
```

### `lib/common/map/map_dr.rb` (+22/-4)

- **`json_extra_fields`** — overrides the MapBase hook to return `{ genie_id:, genie_zone:, genie_pos: }`
- **attr_accessor** — added `:genie_id, :genie_zone, :genie_pos`
- **initialize** — added `genie_id = nil, genie_zone = nil, genie_pos = nil` parameters (after existing `_room_objects`), with corresponding instance variable assignments
- **`by_genie_ref(zone_id, node_id)`** — new class method that finds a room by matching `genie_zone` and `genie_id` (both coerced to string for comparison)
- **`load_json`** — passes `room['genie_id'], room['genie_zone'], room['genie_pos']` to `new()` when loading from JSON

### `spec/map_base_spec.rb` (new, 560 lines, 53 examples)

Tests for `Lich::Common::MapBase` shared module via a concrete `TestMap::Map` class:

- **MinHeap** — push/pop ordering, empty?, duplicate priorities, 100-element sort
- **InstanceMethods** — `to_i`, `outside?`/`inside?`, `desc`, `map_name`, `map_x`/`map_y`/`map_roomsize`, `geo`, `inspect`, `to_json` (valid JSON, nil exclusion, empty array exclusion, `json_extra_fields` default and merge behavior)
- **ClassMethods** — `get_free_id`, `estimate_time` (sum, default, error), `uids_add`/`ids_from_uid` (add, unknown, dedup), `to_json`
- **Pathfinding** — 3-node weighted graph testing `dijkstra` (distances, previous pointers, early termination), `path_to` (shortest path, no path, adjacent), `find_nearest`, `find_nearest_by_tag`, `find_all_nearest_by_tag`, `findpath`, class-level `dijkstra`

### `spec/map_dr_spec.rb` (new, 248 lines, 18 examples)

Tests for DR-specific `Lich::Common::Map`:

- **Genie fields** — initialize with genie params, nil defaults, attr_accessor read/write
- **`json_extra_fields`** — returns genie fields hash
- **`to_json`** — includes genie fields when present, excludes when nil
- **`by_genie_ref`** — zone+node lookup, cross-zone lookup, nil for nonexistent, integer argument coercion
- **Standard functionality** — `to_s` formatting, `[]` lookup (integer, string, title search), `Room` alias

> **Note:** `map_dr_spec.rb` must be run separately from any future `map_gs_spec.rb` since both define `Lich::Common::Map`.

## Backward Compatibility

- `json_extra_fields` returns `{}` by default — no impact on GS or any existing subclass
- All new DR fields default to `nil` — existing map JSON files load without modification
- `to_json` omits nil/empty fields — existing JSON output is unchanged for rooms without genie data
- `by_genie_ref` returns `nil` when no match exists
- No changes to `map_gs.rb` — GemStone is completely unaffected

## Test Plan

- [x] `rspec spec/map_base_spec.rb` — 53 examples, 0 failures
- [x] `rspec spec/map_dr_spec.rb` — 18 examples, 0 failures
- [ ] Load existing DR map JSON — all rooms load, genie fields are nil
- [ ] Save and reload — round-trip preserves all existing fields, no genie fields appear in output