### PR TITLE
fix(all): guard against broken pipe errors in Game._puts and send_to_client

### DIFF
--- a/lib/games.rb
+++ b/lib/games.rb
@@ -303,6 +303,9 @@ module Lich
           @mutex.synchronize do
             @socket.puts(str)
           end
+        rescue Errno::EPIPE, IOError => e
+          Lich.log "error: _puts: #{e}\n\t#{e.backtrace.first}"
+          nil
         end
 
         def puts(str)
@@ -605,7 +608,11 @@ module Lich
               Lich.log "error: client_thread: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
             end
           else
-            $_CLIENT_.write(alt_string)
+            begin
+              $_CLIENT_.write(alt_string)
+            rescue Errno::EPIPE, IOError => e
+              Lich.log "error: client_thread: #{e}\n\t#{e.backtrace.join("\n\t")}"
+            end
           end
         end
 

--- a/spec/lib/games_spec.rb
+++ b/spec/lib/games_spec.rb
@@ -451,4 +451,95 @@ RSpec.describe Lich::GameBase::Game do
       expect(described_class.autostarted?).to be true
     end
   end
+
+  describe '._puts' do
+    let(:mock_socket) { double('socket') }
+
+    before do
+      described_class.instance_variable_set(:@socket, mock_socket)
+      described_class.instance_variable_set(:@mutex, Mutex.new)
+      allow(Lich).to receive(:log)
+    end
+
+    it 'writes to the socket' do
+      allow(mock_socket).to receive(:puts)
+      described_class.send(:_puts, 'test')
+      expect(mock_socket).to have_received(:puts).with('test')
+    end
+
+    it 'rescues Errno::EPIPE and logs the error' do
+      allow(mock_socket).to receive(:puts).and_raise(Errno::EPIPE)
+      expect { described_class.send(:_puts, 'test') }.not_to raise_error
+      expect(Lich).to have_received(:log).with(/error: _puts: Broken pipe/)
+    end
+
+    it 'rescues IOError and logs the error' do
+      allow(mock_socket).to receive(:puts).and_raise(IOError, 'closed stream')
+      expect { described_class.send(:_puts, 'test') }.not_to raise_error
+      expect(Lich).to have_received(:log).with(/error: _puts: closed stream/)
+    end
+
+    it 'returns nil on broken pipe' do
+      allow(mock_socket).to receive(:puts).and_raise(Errno::EPIPE)
+      expect(described_class.send(:_puts, 'test')).to be_nil
+    end
+  end
+
+  describe '.send_to_client' do
+    before do
+      allow(Lich).to receive(:log)
+    end
+
+    context 'when using detachable client' do
+      let(:mock_detachable) { double('detachable_client') }
+
+      before do
+        $_DETACHABLE_CLIENT_ = mock_detachable
+      end
+
+      after do
+        $_DETACHABLE_CLIENT_ = nil
+      end
+
+      it 'writes to the detachable client' do
+        allow(mock_detachable).to receive(:write)
+        described_class.send(:send_to_client, 'test data')
+        expect(mock_detachable).to have_received(:write).with('test data')
+      end
+
+      it 'rescues errors and cleans up detachable client' do
+        allow(mock_detachable).to receive(:write).and_raise(Errno::EPIPE)
+        allow(mock_detachable).to receive(:close)
+        expect { described_class.send(:send_to_client, 'test data') }.not_to raise_error
+        expect($_DETACHABLE_CLIENT_).to be_nil
+      end
+    end
+
+    context 'when using non-detachable client' do
+      let(:mock_client) { double('client') }
+
+      before do
+        $_DETACHABLE_CLIENT_ = nil
+        $_CLIENT_ = mock_client
+      end
+
+      it 'writes to the client' do
+        allow(mock_client).to receive(:write)
+        described_class.send(:send_to_client, 'test data')
+        expect(mock_client).to have_received(:write).with('test data')
+      end
+
+      it 'rescues Errno::EPIPE without raising' do
+        allow(mock_client).to receive(:write).and_raise(Errno::EPIPE)
+        expect { described_class.send(:send_to_client, 'test data') }.not_to raise_error
+        expect(Lich).to have_received(:log).with(/error: client_thread: Broken pipe/)
+      end
+
+      it 'rescues IOError without raising' do
+        allow(mock_client).to receive(:write).and_raise(IOError, 'closed stream')
+        expect { described_class.send(:send_to_client, 'test data') }.not_to raise_error
+        expect(Lich).to have_received(:log).with(/error: client_thread: closed stream/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add `Errno::EPIPE` / `IOError` rescue to `Game._puts` so broken game server sockets during script at-exit handlers are logged instead of raising unhandled exceptions
- Add the same guard to the non-detachable `$_CLIENT_` path in `Game.send_to_client`, matching the existing detachable client rescue pattern
- Add specs for both `._puts` and `.send_to_client` covering happy path, `Errno::EPIPE`, and `IOError` scenarios

## Context
When a frontend (Profanity/Genie) disconnects or the game server socket closes, `IO#write` / `IO#puts` raises `Errno::EPIPE`. The detachable client path already rescued this, but two paths did not:

1. `_puts` — used by scripts calling `fput`/`put` during at-exit handlers after the game server socket is dead
2. `send_to_client` non-detachable path — used by the main thread forwarding server output to `$_CLIENT_`

This caused cascading `Broken pipe` errors visible in logs, especially during shutdown sequences.

## Test plan
- [x] All 58 `games_spec.rb` examples pass (0 failures)
- [x] New specs verify `_puts` rescues `Errno::EPIPE` and `IOError`, logs via `Lich.log`, and returns `nil`
- [x] New specs verify `send_to_client` rescues on both detachable and non-detachable client paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)