### PR TITLE
fix(all): prevent zombie server deadlock in Active Sessions accept loop

### DIFF
--- a/lib/internal_api/active_sessions.rb
+++ b/lib/internal_api/active_sessions.rb
@@ -81,6 +81,15 @@ module Lich
         @mutex.synchronize do
           return true if service_available?
 
+          # If this process previously owned a server whose accept thread
+          # died, the TCPServer socket is still bound but unserviceable.
+          # Stop it to release the port before attempting a fresh start.
+          if @server && !@server.running?
+            Lich.log('warning: ActiveSessions server thread died -- releasing zombie socket') if Lich.respond_to?(:log)
+            @server.stop
+            @server = nil
+          end
+
           @registry ||= Registry.new
           @server ||= Server.new(
             host: DEFAULT_HOST,

--- a/lib/internal_api/active_sessions/server.rb
+++ b/lib/internal_api/active_sessions/server.rb
@@ -106,18 +106,27 @@ module Lich
         # Accepts inbound socket connections and dispatches each client to its
         # own handler thread.
         #
+        # Individual accept/dispatch errors are logged and retried so that a
+        # transient failure does not kill the thread and leave the TCPServer
+        # socket bound but unserviceable (zombie server).
+        #
         # @return [void]
         def accept_loop
           loop do
             server = @server
             break unless server
 
-            socket = server.accept
-            client_thread = @client_thread_factory.call(socket) { |client| handle_tracked_client(client) }
-            track_client_thread(client_thread)
+            begin
+              socket = server.accept
+              client_thread = @client_thread_factory.call(socket) { |client| handle_tracked_client(client) }
+              track_client_thread(client_thread)
+            rescue IOError, Errno::EBADF
+              # Server socket closed -- normal shutdown path.
+              break
+            rescue StandardError => e
+              Lich.log("warning: ActiveSessions accept_loop error (continuing): #{e.class}: #{e.message}") if defined?(Lich) && Lich.respond_to?(:log)
+            end
           end
-        rescue IOError, Errno::EBADF
-          nil
         end
 
         # Wraps client handling so finished client threads can be removed from


### PR DESCRIPTION
## Summary

- **Accept loop resilience**: Move error handling inside the loop so transient `StandardError` failures are logged and retried, instead of killing the thread and leaving the `TCPServer` socket bound to port 42857
- **Zombie server recovery**: `ensure_service!` now detects when `@server` exists but the accept thread is dead, stops it to release the port, and starts a fresh server

## Problem

The `accept_loop` in `Server` had its `rescue IOError, Errno::EBADF` **outside** the loop. Any unexpected `StandardError` would:

1. Kill the accept thread silently
2. Leave the `TCPServer` socket bound to port 42857
3. New TCP connections would be accepted at the kernel level but never processed (no thread calling `accept`)
4. All `ping` attempts would timeout -- `service_available?` returns `false`
5. `ensure_service!` tries to start a new server but `TCPServer.new` fails with `EADDRINUSE` (old socket still bound)
6. **Deadlock**: no process can register sessions, the launcher times out, and the only recovery is killing the owning process

## Test plan

- [x] All 16 Active Sessions specs pass
- [x] Full CI suite passes (3753 examples, 0 failures)
- [x] Rubocop clean on modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)